### PR TITLE
Handle more exceptions from smtplib when sending mail

### DIFF
--- a/cardinal_pythonlib/email/sendmail.py
+++ b/cardinal_pythonlib/email/sendmail.py
@@ -281,7 +281,11 @@ def send_msg(from_addr: str,
     # Connect
     try:
         session = smtplib.SMTP(host, port)
-    except smtplib.SMTPException as e:
+    except OSError as e:
+        # https://bugs.python.org/issue2118
+        # Not all errors from smtplib are raised as SMTPException
+        # e.g. ConnectionRefusedError when creating the socket
+        # SMTPException is a subclass of OSError since 3.4
         raise RuntimeError(
             f"send_msg: Failed to connect to host {host}, port {port}: {e}")
     try:


### PR DESCRIPTION
It's not well documented but smtplib can raise exceptions that are not SMTPException,
such as ConnectionRefusedError. So if we catch OSError instead of SMTPException
we should be able to handle these as well. Discussion at https://bugs.python.org/issue2118