### PR TITLE
Fix error when creating full text index with SQL Server

### DIFF
--- a/cardinal_pythonlib/sqlalchemy/schema.py
+++ b/cardinal_pythonlib/sqlalchemy/schema.py
@@ -497,8 +497,10 @@ def add_index(
             # Note that the database must also have had a
             #   CREATE FULLTEXT CATALOG somename AS DEFAULT;
             # statement executed on it beforehand.
+            connection = Connection(engine)
             schemaname = (
-                engine.schema_for_object(sqla_table) or MSSQL_DEFAULT_SCHEMA
+                connection.schema_for_object(sqla_table)
+                or MSSQL_DEFAULT_SCHEMA
             )
             if mssql_table_has_ft_index(
                 engine=engine, tablename=tablename, schemaname=schemaname

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -12,6 +12,11 @@ pyramid==1.10.8
 pytest
 # CamCOPS and CRATE both on this version
 sphinx==4.2.0
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinx-paramlinks
 sphinx_rtd_theme
 weasyprint

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -793,3 +793,7 @@ Quick links:
 - Supported SQLAlchemy version now 1.4
 
 **1.1.26 (in progress)**
+
+- Fix ``AttributeError: 'Engine' object has no attribute 'schema_for_object'``
+  when adding a full text index to an anonymised SQL Server database table.
+  This bug has been present since the SQLAlchemy 1.4 upgrade in 1.1.25.


### PR DESCRIPTION
This was overlooked during the SQLAlchemy 1.4 upgrade in the previous release.

