### PR TITLE
Fixes for Django 4.2

### DIFF
--- a/cardinal_pythonlib/django/fields/isodatetimetz.py
+++ b/cardinal_pythonlib/django/fields/isodatetimetz.py
@@ -38,9 +38,6 @@ from django.db import models
 # noinspection PyUnresolvedReferences
 from django.db.models.fields import DateField, DateTimeField, Field
 
-# noinspection PyUnresolvedReferences
-from django.utils import timezone
-
 from cardinal_pythonlib.logs import get_brace_style_log_with_null_handler
 
 log = get_brace_style_log_with_null_handler(__name__)
@@ -256,7 +253,7 @@ class IsoDateTimeTzField(models.CharField):
             # function must always return a string type.
             # https://docs.djangoproject.com/en/1.8/howto/custom-model-fields/
         # Convert to UTC
-        return value.astimezone(timezone.utc)
+        return value.astimezone(datetime.timezone.utc)
 
     def get_db_prep_value(self, value, connection, prepared=False):
         """

--- a/cardinal_pythonlib/django/fields/restrictedcontentfile.py
+++ b/cardinal_pythonlib/django/fields/restrictedcontentfile.py
@@ -43,7 +43,7 @@ from django.db import models
 from django.template.defaultfilters import filesizeformat
 
 # noinspection PyUnresolvedReferences
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 # =============================================================================
@@ -96,7 +96,7 @@ class ContentTypeRestrictedFileField(models.FileField):
         content_type = f.content_type
         if content_type not in self.content_types:
             raise forms.ValidationError(
-                ugettext_lazy("Filetype not supported.")
+                gettext_lazy("Filetype not supported.")
             )
         if hasattr(f, "size"):  # e.g. Django 2.1.2
             uploaded_file_size = f.size
@@ -110,7 +110,7 @@ class ContentTypeRestrictedFileField(models.FileField):
             and uploaded_file_size > self.max_upload_size
         ):
             raise forms.ValidationError(
-                ugettext_lazy(
+                gettext_lazy(
                     "Please keep filesize under %s. Current filesize %s"
                 )
                 % (

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -31,6 +31,8 @@ Quick links:
 - :ref:`2020 <changelog_2020>`
 - :ref:`2021 <changelog_2021>`
 - :ref:`2022 <changelog_2022>`
+- :ref:`2023 <changelog_2023>`
+- :ref:`2024 <changelog_2024>`
 
 
 .. _changelog_2017:
@@ -792,6 +794,8 @@ Quick links:
 
 - Supported SQLAlchemy version now 1.4
 
+.. _changelog_2024:
+
 **1.1.26 (2024-03-03)**
 
 - Fix ``AttributeError: 'Engine' object has no attribute 'schema_for_object'``
@@ -799,3 +803,8 @@ Quick links:
   This bug has been present since the SQLAlchemy 1.4 upgrade in 1.1.25.
 
 **1.1.27 (in progress)**
+
+- Fixes for Django 4.
+
+  - Replace ugettext_* calls removed in Django 4.0.
+    https://docs.djangoproject.com/en/4.2/releases/4.0/#features-removed-in-4-0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ REQUIREMENTS = [
     "colorlog",
     "isodate>=0.5.4",
     "numba",  # just-in-time compilation
-    "numpy>=1.20.0",  # 1.20.0 required for numpy.typing
+    "numpy>=1.20.0,<2.0",  # 1.20.0 required for numpy.typing
     "openpyxl",
     "pandas",
     "pendulum>=2.1.1",

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ NOTES_RE_OTHER_REQUIREMENTS = """
 # bcrypt
 # colander
 # deform
-# Django>=2.0.0
+# Django>=4.2
 # dogpile.cache
 # pyramid
 # webob  # installed by pyramid


### PR DESCRIPTION
Replace instances of `ugettext_lazy()`, which was removed in Django 4.0. The CRATE tests won't start without this fix.
Replace deprecated `django.utils.timezone.utc` in `IsoDateTimeTzField`. This is the only fix made by https://github.com/adamchainz/django-upgrade/.

I accidentally pushed https://github.com/RudolfCardinal/pythonlib/pull/20/commits/db0fa4e2945a19d2f2e6a2ed097985f04e67b417 to master. It's harmless.