### PR TITLE
Close connection after retrieving the current alembic version

### DIFF
--- a/cardinal_pythonlib/sqlalchemy/alembic_func.py
+++ b/cardinal_pythonlib/sqlalchemy/alembic_func.py
@@ -104,10 +104,10 @@ def get_current_revision(
         version_table: table name for Alembic versions
     """
     engine = create_engine(database_url, future=True)
-    conn = engine.connect()
-    opts = {"version_table": version_table}
-    mig_context = MigrationContext.configure(conn, opts=opts)
-    return mig_context.get_current_revision()
+    with engine.connect() as conn:
+        opts = {"version_table": version_table}
+        mig_context = MigrationContext.configure(conn, opts=opts)
+        return mig_context.get_current_revision()
 
 
 def get_current_and_head_revision(

--- a/cardinal_pythonlib/sqlalchemy/tests/schema_tests.py
+++ b/cardinal_pythonlib/sqlalchemy/tests/schema_tests.py
@@ -307,12 +307,14 @@ def _attach_view(
     of "selectable") is created after the table is created, and dropped before
     the table is dropped, via listeners.
     """
-    t = table(tablename)
-
-    # noinspection PyProtectedMember
-    t._columns._populate_separate_keys(
-        col._make_proxy(t) for col in selectable.selected_columns
+    t = table(
+        tablename,
+        *(
+            Column(c.name, c.type, primary_key=c.primary_key)
+            for c in selectable.selected_columns
+        ),
     )
+    t.primary_key.update(c for c in t.c if c.primary_key)
 
     event.listen(
         metadata,

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -852,3 +852,10 @@ Quick links:
 - Bugfix to ``cardinal_pythonlib.sqlalchemy.sqlserver`` functions as they
   were executing unconditionally, regardless of SQLAlchemy dialect (they should
   have been conditional to SQL Server).
+
+**2.0.2**
+
+- Bugfix to
+  :func:`cardinal_pythonlib.sqlalchemy.alembic_func.get_current_revision` where
+  since SQLAlchemy 2.0, the database connection was persisting, resulting in a
+  metadata lock.


### PR DESCRIPTION
Since the upgrade to SQLAlchemy 2.0, CamCOPS `upgrade_db` was hanging when upgrading the database. This appears to be due to this open connection causing a metadata lock.