### PR TITLE
bugfix relating to pdfminer when pdftotext not available, and some related tidying

### DIFF
--- a/cardinal_pythonlib/version_string.py
+++ b/cardinal_pythonlib/version_string.py
@@ -31,5 +31,5 @@ For changelog, see changelog.rst
 
 """
 
-VERSION_STRING = "2.0.1"
+VERSION_STRING = "2.0.2"
 # Use semantic versioning: https://semver.org/

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -859,3 +859,8 @@ Quick links:
   :func:`cardinal_pythonlib.sqlalchemy.alembic_func.get_current_revision` where
   since SQLAlchemy 2.0, the database connection was persisting, resulting in a
   metadata lock.
+
+- Bugfix to :func:`cardinal_pythonlib.extract_text.convert_pdf_to_txt` where
+  ``pdftotext`` was unavailable. Also remove antique ``pyth`` support. And
+  shift from unmaintained ``pdfminer`` to maintained ``pdfminer.six``. Also
+  removed unused code around importing ``docx`` and ``docx2txt``.


### PR DESCRIPTION
For text extraction: pdftotext is preferred; but as fallback, we were using pdfminer and there was a bug relating to legacy Python 2 code. Fixed, but also shifted (for this optional component) to pdfminer.six (maintained), and some other removal of redundant/commented code.