### PR TITLE
Allow db_url parameter to create_database_migration_numbered_style

### DIFF
--- a/cardinal_pythonlib/version_string.py
+++ b/cardinal_pythonlib/version_string.py
@@ -31,5 +31,5 @@ For changelog, see changelog.rst
 
 """
 
-VERSION_STRING = "2.0.2"
+VERSION_STRING = "2.0.3"
 # Use semantic versioning: https://semver.org/

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -873,7 +873,10 @@ Quick links:
 
 - Improve ability of Alembic support code to take a database URL.
 
-**2.0.3**
+**2.0.3 (2023-03-11)**
 
 - Reinstate BIT and similar datatypes in the list of valid datatypes. Broken
   since v2.0.0.
+
+- Allow ``db_url`` parameter to
+  ``cardinal_pythonlib.sqlalchemy.alembic_func.create_database_migration_numbered_style``.


### PR DESCRIPTION
Part of fixing the ``missing-migration-check.yml`` problem in https://github.com/ucam-department-of-psychiatry/camcops/pull/388