### PR TITLE
Fix syntax errors found when running MyPy on CamCOPS

### DIFF
--- a/cardinal_pythonlib/json/serialize.py
+++ b/cardinal_pythonlib/json/serialize.py
@@ -807,7 +807,7 @@ def dict_to_pendulumdate(
     # noinspection PyTypeChecker
     dt = pendulum.parse(d["iso"])  # type: pendulum.DateTime
     # noinspection PyTypeChecker
-    return dt.date()  # type: pendulum.Date
+    return dt.date()
 
 
 register_class_for_json(

--- a/cardinal_pythonlib/sqlalchemy/dialect.py
+++ b/cardinal_pythonlib/sqlalchemy/dialect.py
@@ -148,7 +148,7 @@ def get_preparer(
     """
     dialect = get_dialect(mixed)
     # noinspection PyUnresolvedReferences
-    return dialect.preparer(dialect)  # type: IdentifierPreparer
+    return dialect.preparer(dialect)
 
 
 def quote_identifier(


### PR DESCRIPTION
These are minimal changes to get MyPy working with CamCOPS without ignoring cardinal_pythonlib altogether. I've not done any investigation into why these were failing.