### PR TITLE
Support text extraction from Outlook msg files

### DIFF
--- a/cardinal_pythonlib/extract_text.py
+++ b/cardinal_pythonlib/extract_text.py
@@ -1362,8 +1362,7 @@ def _gen_msg_content(
     for attachment in message.attachments:
         # null termination seen in the real world
         # https://github.com/TeamMsgExtractor/msg-extractor/issues/464
-        content_type = attachment.mimetype.replace("\x00", "")
-        ext = guess_extension(content_type)
+        ext = attachment.extension.replace("\x00", "")
         if ext is not None and ext in ext_map:
             yield document_to_text(
                 blob=attachment.data, extension=ext, config=config

--- a/cardinal_pythonlib/extract_text.py
+++ b/cardinal_pythonlib/extract_text.py
@@ -1336,10 +1336,19 @@ def convert_msg_to_text(
 ) -> str:
     message_content_list: list[str] = []
 
-    if blob is not None:
-        raise ValueError("Blob not currently supported for Outlook msg format")
+    if not filename and blob is None:
+        raise ValueError("convert_msg_to_text: no filename and no blob")
+    if filename and blob:
+        raise ValueError(
+            "convert_msg_to_text: specify either filename or blob"
+        )
 
-    message = openMsg(filename, delayAttachments=False)
+    if blob is not None:
+        filename_or_blob = blob
+    else:
+        filename_or_blob = filename
+
+    message = openMsg(filename_or_blob, delayAttachments=False)
     for message_content in _gen_msg_content(message, config=config):
         if message_content_list is not None:
             message_content_list.append(message_content)

--- a/cardinal_pythonlib/extract_text.py
+++ b/cardinal_pythonlib/extract_text.py
@@ -100,6 +100,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    TYPE_CHECKING,
 )
 from xml.etree import ElementTree as ElementTree
 import zipfile
@@ -107,6 +108,7 @@ import zipfile
 import bs4
 import chardet
 from chardet.universaldetector import UniversalDetector
+from extract_msg import openMsg
 import pdfminer  # pip install pdfminer.six
 import pdfminer.pdfinterp
 import pdfminer.converter
@@ -117,6 +119,8 @@ from semantic_version import Version
 
 from cardinal_pythonlib.logs import get_brace_style_log_with_null_handler
 
+if TYPE_CHECKING:
+    from extract_msg import MSGFile
 
 log = get_brace_style_log_with_null_handler(__name__)
 
@@ -1321,6 +1325,52 @@ def _get_email_content(
 
 
 # =============================================================================
+# MSG (Outlook binary format)
+# =============================================================================
+
+
+def convert_msg_to_text(
+    filename: str = None,
+    blob: bytes = None,
+    config: TextProcessingConfig = _DEFAULT_CONFIG,
+) -> str:
+    message_content_list: list[str] = []
+
+    if blob is not None:
+        raise ValueError("Blob not currently supported for Outlook msg format")
+
+    message = openMsg(filename, delayAttachments=False)
+    for message_content in _gen_msg_content(message, config=config):
+        if message_content_list is not None:
+            message_content_list.append(message_content)
+
+    text = "\n".join(message_content_list)
+
+    return text
+
+
+def _gen_msg_content(
+    message: "MSGFile", config: TextProcessingConfig
+) -> Generator[Optional[str], None, None]:
+    if message.body is not None:
+        yield message.body
+    elif message.htmlBody is not None:
+        yield document_to_text(
+            blob=message.htmlBody, extension=".htm", config=config
+        )
+
+    for attachment in message.attachments:
+        # null termination seen in the real world
+        # https://github.com/TeamMsgExtractor/msg-extractor/issues/464
+        content_type = attachment.mimetype.replace("\x00", "")
+        ext = guess_extension(content_type)
+        if ext is not None and ext in ext_map:
+            yield document_to_text(
+                blob=attachment.data, extension=ext, config=config
+            )
+
+
+# =============================================================================
 # Anything
 # =============================================================================
 
@@ -1371,12 +1421,7 @@ ext_map: dict[str, dict[str, Any]] = {
     ".htm": {CONVERTER: convert_html_to_text, AVAILABILITY: True},
     ".html": {CONVERTER: convert_html_to_text, AVAILABILITY: True},
     ".log": {CONVERTER: get_file_contents_text, AVAILABILITY: True},
-    # .msg is often Outlook binary, not text
-    #
-    # '.msg': {
-    #     CONVERTER: get_file_contents_text,
-    #     AVAILABILITY: True,
-    # },
+    ".msg": {CONVERTER: convert_msg_to_text, AVAILABILITY: True},
     ".odt": {CONVERTER: convert_odt_to_text, AVAILABILITY: True},
     ".pdf": {CONVERTER: convert_pdf_to_txt, AVAILABILITY: availability_pdf},
     ".rtf": {CONVERTER: convert_rtf_to_text, AVAILABILITY: availability_rtf},

--- a/cardinal_pythonlib/tests/extract_text_tests.py
+++ b/cardinal_pythonlib/tests/extract_text_tests.py
@@ -677,7 +677,7 @@ class ConvertMsgToTextTests(ExtractTextTestCase):
         mock_attachment = mock.Mock(
             # null termination seen in the real world
             # https://github.com/TeamMsgExtractor/msg-extractor/issues/464
-            mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document\x00",  # noqa: E501
+            extension=".docx",
             data=BytesIO(docx).read(),
         )
         mock_msgfile = mock.Mock(

--- a/cardinal_pythonlib/tests/extract_text_tests.py
+++ b/cardinal_pythonlib/tests/extract_text_tests.py
@@ -700,7 +700,7 @@ class ConvertMsgToTextTests(ExtractTextTestCase):
         mock_attachment = mock.Mock(
             # null termination seen in the real world
             # https://github.com/TeamMsgExtractor/msg-extractor/issues/464
-            extension=".docx",
+            extension=".docx\x00",
             data=BytesIO(docx).read(),
         )
         mock_msgfile = mock.Mock(

--- a/cardinal_pythonlib/tests/extract_text_tests.py
+++ b/cardinal_pythonlib/tests/extract_text_tests.py
@@ -116,13 +116,13 @@ class DocumentToTextTests(ExtractTextTestCase):
 
     def test_raises_when_filename_and_blob(self) -> None:
         with self.assertRaises(ValueError) as cm:
-            document_to_text(filename="foo", blob="bar")
+            document_to_text(filename="foo", blob=b"bar")
 
         self.assertIn("specify either filename or blob", str(cm.exception))
 
     def test_raises_when_blob_but_no_extension(self) -> None:
         with self.assertRaises(ValueError) as cm:
-            document_to_text(blob="bar")
+            document_to_text(blob=b"bar")
 
         self.assertIn("need extension hint for blob", str(cm.exception))
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -902,3 +902,9 @@ Quick links:
 - Add support for ``.eml`` files with attachments processed by supported
   document converters (``.docx``, ``.pdf``, ``.odt`` etc.) to
   :func:`cardinal_pythonlib.extract_text.document_to_text`.
+
+**2.1.1**
+
+- Add support for Outlook ``.msg`` files with attachments processed by supported
+  document converters (``.docx``, ``.pdf``, ``.odt`` etc.) to
+  :func:`cardinal_pythonlib.extract_text.document_to_text`.

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ REQUIREMENTS = [
     "beautifulsoup4",  # "import bs4" or "from bs4 import ..."
     "chardet>=5.0.0",
     "colorlog",
+    "extract_msg",
     "isodate>=0.5.4",
     "numba",  # just-in-time compilation
     "numpy>=1.20.0,<2.0",  # 1.20.0 required for numpy.typing


### PR DESCRIPTION
Use [extract-msg](https://pypi.org/project/extract-msg/) a.k.a [msg-extractor](https://github.com/TeamMsgExtractor/msg-extractor) to convert Outlook msg files to text.
