### PR TITLE
Skip extraction of text from Outlook .msg files where the file extension is null or missing (e.g. SignedAttachment)

### DIFF
--- a/cardinal_pythonlib/extract_text.py
+++ b/cardinal_pythonlib/extract_text.py
@@ -1369,13 +1369,14 @@ def _gen_msg_content(
         )
 
     for attachment in message.attachments:
-        # null termination seen in the real world
-        # https://github.com/TeamMsgExtractor/msg-extractor/issues/464
-        ext = attachment.extension.replace("\x00", "")
-        if ext is not None and ext in ext_map:
-            yield document_to_text(
-                blob=attachment.data, extension=ext, config=config
-            )
+        if (ext := attachment.extension) is not None:
+            # null termination seen in the real world
+            # https://github.com/TeamMsgExtractor/msg-extractor/issues/464
+            ext = ext.replace("\x00", "")
+            if ext in ext_map:
+                yield document_to_text(
+                    blob=attachment.data, extension=ext, config=config
+                )
 
 
 # =============================================================================

--- a/cardinal_pythonlib/extract_text.py
+++ b/cardinal_pythonlib/extract_text.py
@@ -1369,13 +1369,13 @@ def _gen_msg_content(
         )
 
     for attachment in message.attachments:
-        if (ext := attachment.extension) is not None:
+        if (extension := getattr(attachment, "extension", None)) is not None:
             # null termination seen in the real world
             # https://github.com/TeamMsgExtractor/msg-extractor/issues/464
-            ext = ext.replace("\x00", "")
-            if ext in ext_map:
+            extension = extension.replace("\x00", "")
+            if extension in ext_map:
                 yield document_to_text(
-                    blob=attachment.data, extension=ext, config=config
+                    blob=attachment.data, extension=extension, config=config
                 )
 
 

--- a/cardinal_pythonlib/tests/extract_text_tests.py
+++ b/cardinal_pythonlib/tests/extract_text_tests.py
@@ -735,3 +735,27 @@ class ConvertMsgToTextTests(ExtractTextTestCase):
             converted = convert_msg_to_text(dummy_filename, config=self.config)
 
         self.assertEqual(converted.strip(), content)
+
+    def test_attachment_with_no_extension_skipped(self) -> None:
+        self.fake.add_provider(DocxFileProvider)
+
+        dummy_filename = "dummy_filename.msg"
+
+        content = self.fake.paragraph(nb_sentences=10)
+        docx = self.fake.docx_file(content=content, raw=True)
+        mock_attachment = mock.Mock(
+            extension=None,
+            data=BytesIO(docx).read(),
+        )
+        mock_msgfile = mock.Mock(
+            body=None, htmlBody=None, attachments=[mock_attachment]
+        )
+        mock_openmsg = mock.Mock(return_value=mock_msgfile)
+        with mock.patch.multiple(
+            "cardinal_pythonlib.extract_text",
+            openMsg=mock_openmsg,
+        ):
+            self.config.width = 0
+            converted = convert_msg_to_text(dummy_filename, config=self.config)
+
+        self.assertEqual(converted.strip(), "")

--- a/cardinal_pythonlib/tests/extract_text_tests.py
+++ b/cardinal_pythonlib/tests/extract_text_tests.py
@@ -33,6 +33,7 @@ import subprocess
 from tempfile import mkdtemp, NamedTemporaryFile
 from unittest import mock, TestCase
 
+from extract_msg import SignedAttachment
 from faker import Faker
 from faker_file.providers.docx_file import DocxFileProvider
 from faker_file.providers.eml_file import EmlFileProvider
@@ -736,7 +737,7 @@ class ConvertMsgToTextTests(ExtractTextTestCase):
 
         self.assertEqual(converted.strip(), content)
 
-    def test_attachment_with_no_extension_skipped(self) -> None:
+    def test_attachment_with_null_extension_skipped(self) -> None:
         self.fake.add_provider(DocxFileProvider)
 
         dummy_filename = "dummy_filename.msg"
@@ -745,6 +746,30 @@ class ConvertMsgToTextTests(ExtractTextTestCase):
         docx = self.fake.docx_file(content=content, raw=True)
         mock_attachment = mock.Mock(
             extension=None,
+            data=BytesIO(docx).read(),
+        )
+        mock_msgfile = mock.Mock(
+            body=None, htmlBody=None, attachments=[mock_attachment]
+        )
+        mock_openmsg = mock.Mock(return_value=mock_msgfile)
+        with mock.patch.multiple(
+            "cardinal_pythonlib.extract_text",
+            openMsg=mock_openmsg,
+        ):
+            self.config.width = 0
+            converted = convert_msg_to_text(dummy_filename, config=self.config)
+
+        self.assertEqual(converted.strip(), "")
+
+    def test_signed_attachment_with_no_extension_skipped(self) -> None:
+        self.fake.add_provider(DocxFileProvider)
+
+        dummy_filename = "dummy_filename.msg"
+
+        content = self.fake.paragraph(nb_sentences=10)
+        docx = self.fake.docx_file(content=content, raw=True)
+        mock_attachment = mock.Mock(
+            spec=SignedAttachment,
             data=BytesIO(docx).read(),
         )
         mock_msgfile = mock.Mock(

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -910,6 +910,11 @@ Quick links:
   document converters (``.docx``, ``.pdf``, ``.odt`` etc.) to
   :func:`cardinal_pythonlib.extract_text.document_to_text`.
 
+.. _changelog_2026:
+
+2026
+~~~~
+
 **2.1.2 (2026-01-27)**
 
 - ``cardinalpythonlib_grep_in_openxml``: new facility to search XML node text
@@ -919,9 +924,9 @@ Quick links:
 - Fix extraction of text from HTML files in
   :func:`cardinal_pythonlib.extract_text.document_to_text`.
 
-.. _changelog_2026:
-
-2026
-~~~~
 
 **2.1.3 (IN PROGRESS)**
+
+- Skip extraction of text from Outlook ``.msg`` files where the file extension
+  is null or missing (SignedAttachment).
+  :func:`cardinal_pythonlib.extract_text.document_to_text`.


### PR DESCRIPTION
Fixes two related bugs discovered when extracting text from Outlook ``.msg`` attachments  in the real world:

* 'NoneType' object has no attribute 'replace'
* 'SignedAttachment' object has no attribute 'extension'

These were because:

* Not all Outlook ``.msg`` files have extension set.
* Some have the extension set but it is null.

Currently we determine the types of these attachments by their file extensions so we can't really do anything with the text, but we can handle the errors more gracefully.